### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Run Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["**"]


### PR DESCRIPTION
Potential fix for [https://github.com/jirikrucek/ricochet-tournament-organization-app/security/code-scanning/1](https://github.com/jirikrucek/ricochet-tournament-organization-app/security/code-scanning/1)

To fix the problem, explicitly declare the minimal required `GITHUB_TOKEN` permissions in the workflow. For a pure test job that only reads the repository and does not push commits, modify issues, or update PRs, `contents: read` is sufficient and aligns with the recommended baseline.

The best fix without changing existing functionality is to add a `permissions` block at the workflow root (so it applies to all jobs) right after the `name:` declaration, with `contents: read`. This keeps the current behavior of the `test` job (it still has read access to the code via `actions/checkout`) while preventing unintended write capabilities if the repository/organization default is broader. No imports or additional methods are needed since this is a YAML configuration change only.

Concretely, edit `.github/workflows/test.yml` to insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Run Tests`) and the existing `on:` block. No changes are required within the `jobs:` section.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
