### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,8 @@ on:
     branches: [ main ]
 jobs:
   test:
+    permissions:
+      contents: read
     name: Playwright
     timeout-minutes: 60
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jirikrucek/ricochet-tournament-organization-app/security/code-scanning/3](https://github.com/jirikrucek/ricochet-tournament-organization-app/security/code-scanning/3)

In general, this issue is fixed by explicitly specifying a minimal `permissions` block for the `GITHUB_TOKEN` at the workflow root or per job, instead of relying on repository defaults. For a typical Playwright test workflow that only checks out code, installs dependencies, runs tests, and uploads artifacts, read-only access to repository contents is sufficient; no write permissions or additional scopes (like `pull-requests`, `issues`, or `actions`) are needed.

The best low-impact fix here is to add a `permissions` block with `contents: read` scoped to the `test` job, since that is the only job shown. This will ensure the `GITHUB_TOKEN` used by `actions/checkout@v4` can read the repository but cannot push changes or otherwise modify contents, and it will not change any existing behavior of the workflow. Concretely, in `.github/workflows/playwright.yml`, under `jobs: test:`, insert a `permissions:` section before the other job properties (e.g., before `name: Playwright`). No additional imports, methods, or definitions are required since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
